### PR TITLE
fix for dynamic zero padding for invoice numbers

### DIFF
--- a/billing-invoice/src/index.ts
+++ b/billing-invoice/src/index.ts
@@ -222,7 +222,6 @@ function setInvoiceNumbersForProject(projects:any, lastInvoiceNumber:string){
     let invoiceNumberPrefix = config['invoiceNumberPrefix'];
     lastInvoiceNumber = lastInvoiceNumber.replace(invoiceNumberPrefix,"");
     let lastSequence = Number(lastInvoiceNumber);
-    let leadingZeros = lastInvoiceNumber.replace(lastSequence + "","");
     projects.map((item) => {
         let projectSequence = lastSequence + increment;
         increment++;

--- a/billing-invoice/src/index.ts
+++ b/billing-invoice/src/index.ts
@@ -196,8 +196,8 @@ function combineProjectUsers(projects:Array<any>): Array<any> {
     return _.values(output);
 }
 
-function buildInvoiceNumber(prefix:string, projectSequence:number, maxChars:number){
-  let separator = "-"
+function buildInvoiceNumber(prefix:string, projectSequence:number, maxChars:number) : string {
+  let separator = '-';
   let numCharsInSequence = projectSequence.toString().length;
   let numLeadingZeros = maxChars - separator.length - numCharsInSequence - prefix.length;
 
@@ -210,7 +210,7 @@ function buildInvoiceNumber(prefix:string, projectSequence:number, maxChars:numb
   let output = prefix+separator;
   var i;
   for (i =0 ; i < numLeadingZeros ; i++){
-    output += "0";
+    output += '0';
   }
   output += projectSequence;
   return output;

--- a/billing-invoice/src/index.ts
+++ b/billing-invoice/src/index.ts
@@ -196,8 +196,29 @@ function combineProjectUsers(projects:Array<any>): Array<any> {
     return _.values(output);
 }
 
+function buildInvoiceNumber(prefix:string, projectSequence:number, maxChars:number){
+  let separator = "-"
+  let numCharsInSequence = projectSequence.toString().length;
+  let numLeadingZeros = maxChars - separator.length - numCharsInSequence - prefix.length;
+
+  // Check for errors
+  if (numLeadingZeros < 0){
+    // how do you handle the case where you cannot make anymore invoices?
+  }
+
+  // Build the output
+  let output = prefix+separator;
+  var i;
+  for (i =0 ; i < numLeadingZeros ; i++){
+    output += "0";
+  }
+  output += projectSequence;
+  return output;
+}
+
 function setInvoiceNumbersForProject(projects:any, lastInvoiceNumber:string){
     let increment = 1;
+    let maxCharsInInvoiceNumber = 10;
     let invoiceNumberPrefix = config['invoiceNumberPrefix'];
     lastInvoiceNumber = lastInvoiceNumber.replace(invoiceNumberPrefix,"");
     let lastSequence = Number(lastInvoiceNumber);
@@ -205,7 +226,7 @@ function setInvoiceNumbersForProject(projects:any, lastInvoiceNumber:string){
     projects.map((item) => {
         let projectSequence = lastSequence + increment;
         increment++;
-        item["invoiceNumber"] = invoiceNumberPrefix +  leadingZeros + projectSequence;
+        item["invoiceNumber"] = buildInvoiceNumber(invoiceNumberPrefix, projectSequence, maxCharsInInvoiceNumber);
     });
 }
 


### PR DESCRIPTION
Freshbooks can only accept a maximum of 10 characters. Since 3 were used for a prefix, 1 for a hyphen, and 3 leading zeros is effectively bake in, that only allowed for a number as high as 999 to be used. When the number is higher, freshbooks errors out. 

This properly builds the correct invoice number with dynamic padding.